### PR TITLE
Fix the path to the logs folder, so that it's local and not absolute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ venv.bak/
 
 #IDEs
 .vscode
+.idea
 
 # Rope project settings
 .ropeproject

--- a/src/brain_pycore/logging.py
+++ b/src/brain_pycore/logging.py
@@ -16,7 +16,7 @@ import os
 
 CONFIG_LOG_FORMAT = "%(relativeCreated)8d [%(levelname).1s] %(name)-s:  %(message)s"
 CONFIG_DONT_PRINT_TO_FILES = False
-CONFIG_LOG_DIR = "/zakhar/logs"
+CONFIG_LOG_DIR = "zakhar/logs"
 
 
 class LOG_LEVEL(IntEnum):


### PR DESCRIPTION
When run on Linux, "/zakhar/logs" means that the logs folder will be created right under the root. I'm suspecting that the intention was to create a local folder instead. I got a permission denied error when I tried to execute it as is.